### PR TITLE
Add enemy health bars and improve title screen cover

### DIFF
--- a/js/enemies.js
+++ b/js/enemies.js
@@ -49,6 +49,18 @@ class Enemy {
             padding: { left: 1, right: 1, top: 0, bottom: 0 }
         }).setOrigin(0.5).setDepth(59);
 
+        // Health bar
+        const barWidth = type === 'abomination' ? 20 : 14;
+        this._hpBarWidth = barWidth;
+        this.hpBarBg = scene.add.rectangle(
+            this.sprite.x, this.sprite.y - 8,
+            barWidth, 2, 0x333333
+        ).setOrigin(0.5).setDepth(58);
+        this.hpBarFg = scene.add.rectangle(
+            this.sprite.x, this.sprite.y - 8,
+            barWidth, 2, 0x44cc44
+        ).setOrigin(0.5).setDepth(59);
+
         // Stats based on type, scaled by difficulty
         const dm = difficultyMult;
         // Speed escalation: enemies start at half speed and scale up with difficulty
@@ -134,6 +146,20 @@ class Enemy {
         if (!this.alive) return;
 
         this.label.setPosition(this.sprite.x, this.sprite.y - 12);
+
+        // Update health bar
+        const hpRatio = Math.max(0, this.hp / this.maxHp);
+        const barW = this._hpBarWidth * hpRatio;
+        this.hpBarBg.setPosition(this.sprite.x, this.sprite.y - 7);
+        this.hpBarFg.setPosition(
+            this.sprite.x - (this._hpBarWidth - barW) / 2,
+            this.sprite.y - 7
+        );
+        this.hpBarFg.width = barW;
+        // Color: green > yellow > red
+        if (hpRatio > 0.6) this.hpBarFg.setFillStyle(0x44cc44);
+        else if (hpRatio > 0.3) this.hpBarFg.setFillStyle(0xcccc22);
+        else this.hpBarFg.setFillStyle(0xcc2222);
 
         // Update animation based on state
         this._updateEnemyAnimation();
@@ -389,6 +415,8 @@ class Enemy {
 
         // Animated death: shrink + fade out, then destroy
         this.label.destroy();
+        if (this.hpBarBg) this.hpBarBg.destroy();
+        if (this.hpBarFg) this.hpBarFg.destroy();
         this.sprite.setTint(0xff0000);
         this._playEnemyAnim('death');
         this.scene.tweens.add({

--- a/js/scenes/TitleScene.js
+++ b/js/scenes/TitleScene.js
@@ -19,13 +19,15 @@ class TitleScene extends Phaser.Scene {
         this.cameras.main.setBackgroundColor('#0a0a0a');
 
         // Cover art — subtle background, centered and faded
-        const cover = this.add.image(cx, cy - 20, 'cover_art');
-        cover.setAlpha(0.12);
+        const cover = this.add.image(cx, cy - 10, 'cover_art');
+        cover.setAlpha(0.25);
         cover.setOrigin(0.5);
-        // Scale to fit nicely without dominating (about 70% of game height)
-        const targetHeight = CONFIG.GAME_HEIGHT * 0.7;
+        // Scale to fit nicely without dominating (about 80% of game height)
+        const targetHeight = CONFIG.GAME_HEIGHT * 0.8;
         cover.setScale(targetHeight / cover.height);
         cover.setDepth(0);
+        // Red tint to match the theme and prevent washed-out colors
+        cover.setTint(0xff4444);
 
         // Title
         this.add.text(cx, cy - 100, 'PRESIDENT\nDEVIL', {


### PR DESCRIPTION
## Changes
- Each enemy now displays a color-coded health bar (green > yellow > red)
- Health bars update position and width in real-time as enemies move and take damage
- Abominations get wider health bars
- Title screen cover opacity increased to 25% with red tint for better visibility