### PR TITLE
chore: gate sprite generator logs behind CONFIG.DEBUG

### DIFF
--- a/js/enemySpriteGenerator.js
+++ b/js/enemySpriteGenerator.js
@@ -62,7 +62,9 @@ const ENEMY_SPRITE_GEN = {
     },
 
     generate(scene) {
-        console.log('[EnemySpriteGen] Generating enemy spritesheets...');
+        if (CONFIG.DEBUG) {
+            console.log('[EnemySpriteGen] Generating enemy spritesheets...');
+        }
         for (const [typeName, cfg] of Object.entries(this.TYPES)) {
             const texKey = `enemy_${typeName}`;
             const W = cfg.frameW * cfg.cols;
@@ -98,9 +100,13 @@ const ENEMY_SPRITE_GEN = {
 
             // Define animations
             this._defineAnims(scene, texKey, typeName);
-            console.log(`[EnemySpriteGen] ${typeName}: ${W}x${H} canvas, texture=${texKey}, frames registered`);
+            if (CONFIG.DEBUG) {
+                console.log(`[EnemySpriteGen] ${typeName}: ${W}x${H} canvas, texture=${texKey}, frames registered`);
+            }
         }
-        console.log('[EnemySpriteGen] All enemy spritesheets generated successfully.');
+        if (CONFIG.DEBUG) {
+            console.log('[EnemySpriteGen] All enemy spritesheets generated successfully.');
+        }
     },
 
     // ── Pixel helper ──

--- a/js/itemSpriteGenerator.js
+++ b/js/itemSpriteGenerator.js
@@ -17,7 +17,9 @@ const ITEM_SPRITE_GEN = {
     FH: 16,
 
     generate(scene) {
-        console.log('[ItemSpriteGen] Generating item spritesheets...');
+        if (CONFIG.DEBUG) {
+            console.log('[ItemSpriteGen] Generating item spritesheets...');
+        }
 
         const items = {
             // Weapons
@@ -59,10 +61,14 @@ const ITEM_SPRITE_GEN = {
                 scene.textures.remove(texKey);
             }
             scene.textures.addCanvas(texKey, canvas);
-            console.log(`[ItemSpriteGen] ${texKey} created`);
+            if (CONFIG.DEBUG) {
+                console.log(`[ItemSpriteGen] ${texKey} created`);
+            }
         }
 
-        console.log('[ItemSpriteGen] All item sprites generated.');
+        if (CONFIG.DEBUG) {
+            console.log('[ItemSpriteGen] All item sprites generated.');
+        }
     },
 
     // ── Helpers ──

--- a/js/tileSpriteGenerator.js
+++ b/js/tileSpriteGenerator.js
@@ -15,7 +15,9 @@ const TILE_SPRITE_GEN = {
     FH: 16,
 
     generate(scene) {
-        console.log('[TileSpriteGen] Generating tile textures...');
+        if (CONFIG.DEBUG) {
+            console.log('[TileSpriteGen] Generating tile textures...');
+        }
 
         const tiles = {
             // Walls
@@ -78,10 +80,14 @@ const TILE_SPRITE_GEN = {
                 scene.textures.remove(texKey);
             }
             scene.textures.addCanvas(texKey, canvas);
-            console.log(`[TileSpriteGen] ${texKey} created`);
+            if (CONFIG.DEBUG) {
+                console.log(`[TileSpriteGen] ${texKey} created`);
+            }
         }
 
-        console.log('[TileSpriteGen] All tile textures generated.');
+        if (CONFIG.DEBUG) {
+            console.log('[TileSpriteGen] All tile textures generated.');
+        }
     },
 
     // ── Helpers ──


### PR DESCRIPTION
## What this PR does
This updates sprite generator logging to follow the existing debug-toggle pattern.

### Scope (Issue #33)
- `js/tileSpriteGenerator.js`
- `js/itemSpriteGenerator.js`
- `js/enemySpriteGenerator.js`

### Changes
- Wrapped generator `console.log` calls in `if (CONFIG.DEBUG) { ... }`
- Kept diagnostic output available when debugging
- No gameplay logic or rendering behavior changes

### Validation
- No diagnostics in modified files
- Logs in scoped files are now emitted only under `CONFIG.DEBUG`

Closes #33